### PR TITLE
Updating Land Cover

### DIFF
--- a/datasources/National_Datasets/Land.ejs
+++ b/datasources/National_Datasets/Land.ejs
@@ -496,7 +496,7 @@
             },
             {
               "url": "http://services.ga.gov.au/gis/services/Land_Cover_WM/MapServer/WMSServer?service=WMS&request=GetCapabilities",
-              "layers": "Land_Cover_Class"
+              "layers": "Land_Cover_Class",
               "type": "wms",
               "rectangle": [
                 110,

--- a/datasources/National_Datasets/Land.ejs
+++ b/datasources/National_Datasets/Land.ejs
@@ -495,8 +495,9 @@
               ]
             },
             {
-              "url": "http://services.ga.gov.au/gis/rest/services/Landcover_WM/MapServer",
-              "type": "esri-mapServer",
+              "url": "http://services.ga.gov.au/gis/services/Land_Cover_WM/MapServer/WMSServer?service=WMS&request=GetCapabilities",
+              "layers": "Land_Cover_Class"
+              "type": "wms",
               "rectangle": [
                 110,
                 -45.00479,


### PR DESCRIPTION
Looks like it was broken by a recent change at GA changed to service at: http://www.ga.gov.au/metadata-gateway/metadata/record/gcat_8ed70b25-5a21-410d-9b47-dca0b5180323/Australian+Land+Cover+%28Web+Mercator%29+WMS