### PR TITLE
Update vic.ejs to use HTTPS

### DIFF
--- a/datasources/includes/VIC.ejs
+++ b/datasources/includes/VIC.ejs
@@ -326,7 +326,7 @@
         "fq=+(res_format%3Awms%20OR%20res_format%3AWMS)",
         "fq=+(res_format%3Akmz%20OR%20res_format%3Ageojson%20OR%20res_format%3Acsv-geo-au%20OR%20res_format%3Aaus-geo-csv)"      
       ],
-      "url": "http://www.data.vic.gov.au/data",
+      "url": "https://www.data.vic.gov.au/data",
       "includeCsv": true,
       "includeKml": true,
       "ungroupedTitle": "(No group)",


### PR DESCRIPTION
NationalMap is currently returning a 500 error when trying to open the top level Victorian Government catalogue folder.