### PR TITLE
Remove 32 day duration on daily observations

### DIFF
--- a/datasources/National_Datasets/Water.ejs
+++ b/datasources/National_Datasets/Water.ejs
@@ -240,18 +240,15 @@
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat3_C_B_1_DailyMean",
-                      "title": "Daily average",
-                      "defaultDuration": "32d"
+                      "title": "Daily average"
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat3_C_B_1_DailyMin",
-                      "title": "Daily minimum",
-                      "defaultDuration": "32d"
+                      "title": "Daily minimum"
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat3_C_B_1_DailyMax",
-                      "title": "Daily maximum",
-                      "defaultDuration": "32d"
+                      "title": "Daily maximum"
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat3_C_B_1_HourlyMean",
@@ -290,18 +287,15 @@
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat4_C_B_1_DailyMean",
-                      "title": "Daily average",
-                      "defaultDuration": "32d"
+                      "title": "Daily average"
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat4_C_B_1_DailyMin",
-                      "title": "Daily minimum",
-                      "defaultDuration": "32d"
+                      "title": "Daily minimum"
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat4_C_B_1_DailyMax",
-                      "title": "Daily maximum",
-                      "defaultDuration": "32d"
+                      "title": "Daily maximum"
                     },
                     {
                       "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat4_C_B_1_HourlyMean",


### PR DESCRIPTION
Currently the BoM Sensor Observation Services only retrieve the last 32 days when requesting daily observations. This PR removes that limit at the request of GA.